### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/extension-v6.0.0/src/lib/facebook-parser.ts
+++ b/extension-v6.0.0/src/lib/facebook-parser.ts
@@ -170,7 +170,14 @@ export class FacebookParser extends BaseParser implements ContentParser {
     if (
       src.startsWith('data:image/svg+xml') // SVG icons
       || src.includes('emoji') // Emoji images
-      || src.includes('static.xx.fbcdn.net') // Facebook UI assets
+      || (() => {
+           try {
+             const hostname = new URL(src).hostname;
+             return hostname === 'static.xx.fbcdn.net';
+           } catch {
+             return false; // If URL parsing fails, treat as invalid
+           }
+         })() // Facebook UI assets
       || img.width < 50 // Small icons
       || img.height < 50 // Small icons
       || img.classList.contains('x16dsc37') // Reaction icons class


### PR DESCRIPTION
Potential fix for [https://github.com/alexgutscher26/Replivity-an-AI-powered-social-media/security/code-scanning/1](https://github.com/alexgutscher26/Replivity-an-AI-powered-social-media/security/code-scanning/1)

To resolve the issue, the `src` string should be parsed as a full URL, and its hostname should be validated against a whitelist of allowed hosts. By doing so, we ensure that only URLs genuinely originating from `static.xx.fbcdn.net` or its intended subdomains are allowed. 

This change requires:
1. Parsing the `src` using the `URL` constructor to extract its hostname.
2. Comparing the extracted hostname against a whitelist of explicitly allowed hosts, such as `static.xx.fbcdn.net`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improved URL sanitization in facebook-parser.ts by parsing image src values as full URLs and allowing only those from static.xx.fbcdn.net.

- **Bug Fixes**
 - Prevents bypass of hostname checks by validating the exact hostname instead of using substring matching.

<!-- End of auto-generated description by cubic. -->

